### PR TITLE
Focus on tab for highest level

### DIFF
--- a/src/main/java/delta/games/lotro/gui/character/status/levelling/LevelHistoryEditionPanelController.java
+++ b/src/main/java/delta/games/lotro/gui/character/status/levelling/LevelHistoryEditionPanelController.java
@@ -94,6 +94,7 @@ public class LevelHistoryEditionPanelController
       initTab(pane,currentLevel,endLevel);
       currentLevel=endLevel+1;
     }
+    pane.setSelectedIndex(nbTabs-1);
     panel.add(pane,BorderLayout.CENTER);
     return panel;
   }


### PR DESCRIPTION
Most likely users go to the "Level history editor" to add a date for the most recent level-up, and then it would be nice to end up at that tab. Don't you think, @dmorcellet ?